### PR TITLE
fixes `utils` path of npm version and `qn` package warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ storage: {
     accessKey: 'your access key',
     secretKey: 'your secret key',
     bucket: 'your bucket name',
-    domain: 'http://xx.xx.xx.glb.clouddn.com',
+    origin: 'http://xx.xx.xx.glb.clouddn.com',
     // timeout: 3600000, // default rpc timeout: one hour, optional
     // if your app outside of China, please set `uploadURL` to `http://up.qiniug.com/`
     // uploadURL: 'http://up.qiniu.com/'

--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@ var fs  = require('fs');
 var Promise = require('bluebird');
 var qn = require('qn');
 var moment = require('moment');
-// NOTE: npm version should be `../../core/server/utils`
-var utils = require('../../../core/server/utils');
+var utils = require(process.cwd() + '/core/server/utils');
 
 function QiniuStore(config) {
   this.options = config || {};


### PR DESCRIPTION
1. fixes `utils` path of npm version
2. fixes warning: `qn` package: options.domain deprecated, use options.origin instead
