### PR TITLE
修复无法加载自定义存储适配器的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,25 +13,8 @@ const Promise = require('bluebird');
 const moment = require('moment');
 const qn = require('qn');
 const StorageBase = require('ghost-storage-base');
-
-const cwd = process.cwd();
-let ghostRoot;
-
-if (fs.existsSync(path.join(cwd, 'core'))) {
-  ghostRoot = cwd;
-} else if (fs.existsSync(path.join(cwd, 'current'))) {
-  // installed via ghost cli
-  ghostRoot = path.join(cwd, 'current');
-}
-
-if (!ghostRoot) {
-  throw new Error('Can not get ghost root path!');
-}
-
-const config = require(path.join(ghostRoot, 'core/server/config'));
-const security = require(path.join(ghostRoot, 'core/server/lib/security'));
-const errors = require(path.join(ghostRoot, 'core/server/lib/common/errors'));
-const i18n = require(path.join(ghostRoot, 'core/server/lib/common/i18n'));
+const errors = require('@tryghost/errors');
+const security = require('@tryghost/security');
 const getHash = require('./lib/getHash');
 const logPrefix = '[QiniuStore]';
 
@@ -41,7 +24,6 @@ class QiniuStore extends StorageBase {
 
     this.options = options || {};
     this.client = qn.create(this.options);
-    this.storagePath = config.getContentPath('images');
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   },
   "homepage": "https://github.com/Minwe/qn-store",
   "dependencies": {
+    "@tryghost/errors": "^0.2.3",
+    "@tryghost/security": "^0.1.0",
     "bluebird": "3.5.1",
     "ghost-storage-base": "0.0.1",
     "moment": "2.21.0",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "dependencies": {
     "@tryghost/errors": "^0.2.3",
     "@tryghost/security": "^0.1.0",
-    "bluebird": "3.5.1",
-    "ghost-storage-base": "0.0.1",
-    "moment": "2.21.0",
+    "bluebird": "^3.7.2",
+    "ghost-storage-base": "^0.0.5",
+    "moment": "^2.27.0",
     "qn": "^1.3.0"
   }
 }


### PR DESCRIPTION
我使用 Docker 部署 ghost v3.29.2 版本，按文档配置好 qn-store 后，重启 ghost 服务会提示如下错误：

```
Unable to find storage adapter qn-store in ,/var/lib/ghost/content/adapters/,/var/lib/ghost/versions/3.29.2/core/server/adapters/

new NotFoundError (/var/lib/ghost/versions/3.29.2/node_modules/ghost-ignition/lib/errors/index.js:106:23)
at errorHandler.pageNotFound (/var/lib/ghost/versions/3.29.2/core/server/web/shared/middlewares/error-handler.js:246:10)
at Layer.handle [as handle_request] (/var/lib/ghost/versions/3.29.2/node_modules/express/lib/router/layer.js:95:5)
at trim_prefix (/var/lib/ghost/versions/3.29.2/node_modules/express/lib/router/index.js:317:13)
at /var/lib/ghost/versions/3.29.2/node_modules/express/lib/router/index.js:284:7
at Function.process_params (/var/lib/ghost/versions/3.29.2/node_modules/express/lib/router/index.js:335:12)
at Immediate.next (/var/lib/ghos
```

看错误信息，ghost 的模块文件被放置在 `/var/lib/ghost/versions/3.29.2` 目录下；另外我在 qn-store 中打印了一下日志，看到 cwd 为 `/var/lib/ghost`，而 ghostRoot 为 `/var/lib/ghost/current`，但貌似 ghostRoot 路径下没有文件（或者有可能是软链接，我没有进一步查看），所以加载其中的模块如 `core/server/config` 时，会抛出异常。

在 qn-store 中，所加载的 ghost 内部模块有 config、security、errors 及 i18n 四个，但真正用到的貌似只有 security 及 errors 这两个，而 ghost 有单独提供这两个模块 [@tryghost/ercurity 及 @tryghost/errors](https://github.com/TryGhost/Ghost-Utils)，所以我将它们替换了一下。